### PR TITLE
Add watch namespace configuration for namespace filtering

### DIFF
--- a/main.go
+++ b/main.go
@@ -70,6 +70,8 @@ func main() {
 	flag.IntVar(&k8sBurst, "k8s-burst", k8sQps, "The burst of k8s client")
 	flag.BoolVar(&controllers.Debug, "debug", controllers.Debug, "Enable debug")
 	flag.BoolVar(&enableWebhook, "webhook", false, "Enable webhook for support of v1alpha1 crd & validation")
+	flag.StringVar(&config.WatchNamespace, "watch-namespace", config.WatchNamespace,
+		"Comma-separated list of namespaces that controller manager is restricted to watch. If not set, default is to watch all namespaces.")
 	opts := zap.Options{}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,6 +31,7 @@ var (
 	MaxConcurrentReconcile   = 10
 	MaxConcurrentHealthCheck = 10
 	SyncIntervalSec          = 600
+	WatchNamespace           = ""
 )
 
 func Init(workDir string) error {


### PR DESCRIPTION
  - Introduce a new command-line flag `--watch-namespace` to specify 
     a comma-separated list of namespaces that the controller manager
     is restricted to watch. Defaults to watching all namespaces if not set.
  - Update the `config.go` file to include a `WatchNamespace` variable
     initialized to an empty string.
  - Modify `NewManager` function in `manager.go` to handle the specified
     watch namespaces, allowing for more granular control over which
     namespaces the manager observes.