### PR TITLE
make operator helm chart parallel installable

### DIFF
--- a/charts/milvus-operator/templates/clusterrole.yaml
+++ b/charts/milvus-operator/templates/clusterrole.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: '{{ include "chart.fullname" . }}-manager-role'
+  name: '{{ include "chart.fullname" . }}-manager-role-{{ .Release.Namespace }}'
 rules:
 - apiGroups:
   - ""

--- a/charts/milvus-operator/templates/clusterrolebinding.yaml
+++ b/charts/milvus-operator/templates/clusterrolebinding.yaml
@@ -3,11 +3,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: '{{ include "chart.fullname" . }}-manager-rolebinding'
+  name: '{{ include "chart.fullname" . }}-manager-rolebinding-{{ .Release.Namespace }}'
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: '{{ include "chart.fullname" . }}-manager-role'
+  name: '{{ include "chart.fullname" . }}-manager-role-{{ .Release.Namespace }}'
 subjects:
 - kind: ServiceAccount
   name: {{ include "chart.serviceAccountName" . | quote }}

--- a/charts/milvus-operator/templates/deployment.yaml
+++ b/charts/milvus-operator/templates/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "chart.fullname" . | quote }}
   namespace: {{ .Release.Namespace | quote }}
 spec:
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels: {{- include "chart.selectorLabels" . | nindent 6 }}
   template:
@@ -22,6 +23,7 @@ spec:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=:8080
         - --leader-elect
+        - -watch-namespace={{ .Release.Namespace }}
         {{- if .Values.enableWebhook }}
         - --webhook=true
         {{- end }}

--- a/charts/milvus-operator/templates/mutatingwebhookconfiguration.yaml
+++ b/charts/milvus-operator/templates/mutatingwebhookconfiguration.yaml
@@ -5,7 +5,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{.Release.Namespace}}/{{. | include "chart.fullname"}}-serving-cert'
-  name: '{{ include "chart.fullname" . }}-mutating-webhook-configuration'
+  name: '{{ include "chart.fullname" . }}-mutating-webhook-configuration-{{ .Release.Namespace }}'
 webhooks:
 - admissionReviewVersions:
   - v1

--- a/charts/milvus-operator/templates/role.yaml
+++ b/charts/milvus-operator/templates/role.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: '{{ include "chart.fullname" . }}-leader-election-role'
+  name: '{{ include "chart.fullname" . }}-leader-election-role-{{ .Release.Namespace }}'
   namespace: {{ .Release.Namespace | quote }}
 rules:
 - apiGroups:

--- a/charts/milvus-operator/templates/rolebinding.yaml
+++ b/charts/milvus-operator/templates/rolebinding.yaml
@@ -3,12 +3,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: '{{ include "chart.fullname" . }}-leader-election-rolebinding'
+  name: '{{ include "chart.fullname" . }}-leader-election-rolebinding-{{ .Release.Namespace }}'
   namespace: {{ .Release.Namespace | quote }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: '{{ include "chart.fullname" . }}-leader-election-role'
+  name: '{{ include "chart.fullname" . }}-leader-election-role-{{ .Release.Namespace }}'
 subjects:
 - kind: ServiceAccount
   name: {{ include "chart.serviceAccountName" . | quote }}

--- a/charts/milvus-operator/templates/validatingwebhookconfiguration.yaml
+++ b/charts/milvus-operator/templates/validatingwebhookconfiguration.yaml
@@ -5,7 +5,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{.Release.Namespace}}/{{. | include "chart.fullname"}}-serving-cert'
-  name: '{{ include "chart.fullname" . }}-validating-webhook-configuration'
+  name: '{{ include "chart.fullname" . }}-validating-webhook-configuration-{{ .Release.Namespace }}'
 webhooks:
 - admissionReviewVersions:
   - v1


### PR DESCRIPTION
  - we suffix global objects with -{{ .Release.Namespace }} to allow them to coexist in the same kubernetes cluster